### PR TITLE
fix version prefix for versioneer

### DIFF
--- a/krtc/_version.py
+++ b/krtc/_version.py
@@ -41,7 +41,7 @@ def get_config():
     cfg = VersioneerConfig()
     cfg.VCS = "git"
     cfg.style = "pep440"
-    cfg.tag_prefix = ""
+    cfg.tag_prefix = "v"
     cfg.parentdir_prefix = "None"
     cfg.versionfile_source = "krtc/_version.py"
     cfg.verbose = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,4 +3,4 @@ VCS = git
 style = pep440
 versionfile_source = krtc/_version.py
 versionfile_build  = krtc/_version.py
-tag_prefix = 
+tag_prefix = v


### PR DESCRIPTION
It the recent tags of this package seem to use 'v' as a prefix for tags, so this just a simple fix so version handles the prefix. Conda seems to be unhappy when uploaded packages have 'v' at the beginning of there name. Currently 0.1.0 is considered a higher version than v0.1.1 for example.

It might be worth making a new tag after this so that actual newer version gets picked up from conda.