### PR TITLE
CI: upload from noarch dir since we are a noarch package now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,12 +41,12 @@ after_success:
     if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == $TRAVIS_TAG  && $TRAVIS_TAG != '' && $CONDA_UPLOAD_TOKEN_TAG != '' ]]; then
       conda install anaconda-client
       export ANACONDA_API_TOKEN=$CONDA_UPLOAD_TOKEN_TAG
-      anaconda upload bld-dir/linux-64/*.tar.bz2
+      anaconda upload bld-dir/noarch/*.tar.bz2
     fi
 
   - |
     if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == 'master' && $TRAVIS_TAG == '' && $CONDA_UPLOAD_TOKEN_DEV != '' ]]; then
       conda install anaconda-client
       export ANACONDA_API_TOKEN=$CONDA_UPLOAD_TOKEN_DEV
-      anaconda upload bld-dir/linux-64/*.tar.bz2
+      anaconda upload bld-dir/noarch/*.tar.bz2
     fi


### PR DESCRIPTION
The change from `linux-64` to `noarch` left a hole in the travis CI for build/upload.